### PR TITLE
Update error checking guidelines for clarity and to mention `verify`

### DIFF
--- a/Code/D/assert-vs-enforce.md
+++ b/Code/D/assert-vs-enforce.md
@@ -112,23 +112,22 @@ or not).
 Goals
 =====
 
-All suggested guidelines come from a simple goal - eventually it should be
-possible to compile our applications with `-release` flag without introducing
-serious business risks.
+All suggested guidelines stem from a simple goal -- it should be possible to
+compile our applications with the `-release` flag without introducing serious
+business risks.
 
-"serious business risks" here mean anything that will cause money loss to
-the company - logical violations that can result in broken bid values,
-memory corruption that can damage stored user profiles, simultaneous
-denial of service for majority of deployed services. Crashing or
-small non-corrupting data loss is not considered a serious risk because
-at current system scale it doesn't make a big impact for the system as
-a whole.
+"Serious business risks" here means anything that will cause money loss to the
+company -- logical violations that can result in broken bid values, memory
+corruption that can damage stored user profiles, simultaneous denial of service
+for majority of deployed services, and so on. Crashing or small non-corrupting
+data loss is not considered a serious risk because at the current system scale
+it doesn't make a big impact for the system as a whole.
 
-Considering the before-mentioned issues this goal limits contracts/asserts to
-relative narrow specialization - introducing additional costly sanity checks to
-help in debugging and testing. With such an approach application compiled in
-release mode won't compromise safety - it will simply provide less convenient
-error messages.
+Considering the aforementioned issues, this goal limits contracts/`assert`s to
+a relativly specialised usage -- introducing additional costly sanity checks
+to help in debugging and testing. With such an approach, compiling an
+application in release mode won't compromise safety -- it will simply provide
+less convenient error messages.
 
 Guidelines
 ==========

--- a/Code/D/assert-vs-enforce.md
+++ b/Code/D/assert-vs-enforce.md
@@ -60,7 +60,7 @@ of internal program sanity.
 enforce
 -------
 
-`enforce` is a helper function provided by the `ocean.core.Exception` module and
+`enforce` is a helper function provided by the `ocean.core.Enforce` module and
 originally inspired by Phobos' `std.exception.enforce`. It mimicks the syntax of
 `assert`, but throws a user-defined exception object (`new Exception` by
 default).

--- a/Code/D/assert-vs-enforce.md
+++ b/Code/D/assert-vs-enforce.md
@@ -69,6 +69,18 @@ Enforcements are designed to be a tool for error handling, to conveniently
 protect against possible error conditions that are unlikely in the main code
 flow but can still happen in deployed applications.
 
+verify
+------
+
+`verify` is a helper function provided by the `ocean.core.Verify` module. It
+mimicks the syntax of `assert`, but throws an exception of type
+`SanityException`.
+
+`verify` is designed to be a tool for catching programmer errors and basic
+sanity / safety errors. These are usually considered highly unlikely to occur,
+but must be handled by the normal exception mechanism, if they do occur in a
+live application.
+
 Issues
 ======
 

--- a/Code/D/assert-vs-enforce.md
+++ b/Code/D/assert-vs-enforce.md
@@ -1,4 +1,4 @@
-Relevant concepts explained
+Relevant Concepts Explained
 ===========================
 
 assert


### PR DESCRIPTION
`verify` did not exist when the guide was originally written.