### PR TITLE
README: Add a Code of Conduct links

### DIFF
--- a/Code of Conduct/README.md
+++ b/Code of Conduct/README.md
@@ -1,6 +1,6 @@
 # Sociomantic Code of Conduct v1.2.2
 
-Our Code of Conduct is intended to create a safe and enjoyable working atmosphere for our employees internally as well as our fellow beings externally as well.
+Our [Code of Conduct](Sociomantic Code of Conduct.md) is intended to create a safe and enjoyable working atmosphere for our employees internally as well as our fellow beings externally as well.
 
 # Change Log
 

--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ This repo is intended to hold cultural and process-related materials from inside
 ## Versioning
 
 Based on the unique model of this repository it will not itself be controlled with semantic versioning. Individual documents or collections of documents will be, though. Please review to their own README files for more information.
+
+## Code of Conduct
+
+Our [Code of Conduct](Code of Conduct.md) is intended to create a safe and enjoyable working atmosphere for our employees internally as well as our fellow beings externally as well.


### PR DESCRIPTION
This will make a link in the github page of the project.

We are enabling GitHub pages in a very rudimentary way to make the Code of Conduct available as a simple HTML page, so it can be used by L&D. You can preview how the GitHub page will look like in https://leandro-lucarella-sociomantic.github.io/sociomantic/Code%20of%20Conduct/Sociomantic%20Code%20of%20Conduct for now.

Once this is merged, it will be available via this link:
https://sociomantic-tsunami.github.io/sociomantic/Code%20of%20Conduct/Sociomantic%20Code%20of%20Conduct

And at some point we could even make something like https://tsunami.sociomantic.com/ point to these pages.